### PR TITLE
Refactor API URL configuration using environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+# Local development & test env files
+.env.local
+.env.test

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=https://community-events-board.onrender.com

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
-const testApiUrl = "http://localhost:3000"; // mock or dummy API
-
 export default defineConfig({
   plugins: [react()],
   server: {
@@ -13,8 +11,5 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: "./src/setupTests.ts",
-  },
-  define: {
-    "import.meta.env.VITE_API_URL": JSON.stringify(testApiUrl),
   },
 });


### PR DESCRIPTION
This PR removes the hardcoded VITE_API_URL value from vite.config.ts and shifts API configuration to environment-specific .env files (.env.local for development and .env.test for testing). This change prevents deployment issues caused by referencing localhost in production builds. The updated setup allows Vite to use the appropriate API URL depending on the environment, streamlining both local development and deployment to platforms like Render and Amplify. I also added .env.local and .env.test to .gitignore to avoid leaking environment-specific details.